### PR TITLE
feat: use stdlib pbkdf2 in go 1.24

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,8 +8,6 @@ package scram
 
 import (
 	"sync"
-
-	"github.com/xdg-go/pbkdf2"
 )
 
 // Client implements the client side of SCRAM authentication.  It holds
@@ -81,38 +79,45 @@ func (c *Client) NewConversation() *ClientConversation {
 	}
 }
 
-func (c *Client) getDerivedKeys(kf KeyFactors) derivedKeys {
+func (c *Client) getDerivedKeys(kf KeyFactors) (derivedKeys, error) {
 	dk, ok := c.getCache(kf)
 	if !ok {
-		dk = c.computeKeys(kf)
+		var err error
+		dk, err = c.computeKeys(kf)
+		if err != nil {
+			return derivedKeys{}, err
+		}
 		c.setCache(kf, dk)
 	}
-	return dk
+	return dk, nil
 }
 
 // GetStoredCredentials takes a salt and iteration count structure and
 // provides the values that must be stored by a server to authentication a
 // user.  These values are what the Server credential lookup function must
 // return for a given username.
-func (c *Client) GetStoredCredentials(kf KeyFactors) StoredCredentials {
-	dk := c.getDerivedKeys(kf)
+func (c *Client) GetStoredCredentials(kf KeyFactors) (StoredCredentials, error) {
+	dk, err := c.getDerivedKeys(kf)
 	return StoredCredentials{
 		KeyFactors: kf,
 		StoredKey:  dk.StoredKey,
 		ServerKey:  dk.ServerKey,
-	}
+	}, err
 }
 
-func (c *Client) computeKeys(kf KeyFactors) derivedKeys {
+func (c *Client) computeKeys(kf KeyFactors) (derivedKeys, error) {
 	h := c.hashGen()
-	saltedPassword := pbkdf2.Key([]byte(c.password), []byte(kf.Salt), kf.Iters, h.Size(), c.hashGen)
+	saltedPassword, err := pbkdf2Key(c.hashGen, c.password, []byte(kf.Salt), kf.Iters, h.Size())
+	if err != nil {
+		return derivedKeys{}, err
+	}
 	clientKey := computeHMAC(c.hashGen, saltedPassword, []byte("Client Key"))
 
 	return derivedKeys{
 		ClientKey: clientKey,
 		StoredKey: computeHash(c.hashGen, clientKey),
 		ServerKey: computeHMAC(c.hashGen, saltedPassword, []byte("Server Key")),
-	}
+	}, nil
 }
 
 func (c *Client) getCache(kf KeyFactors) (derivedKeys, bool) {

--- a/client_conv.go
+++ b/client_conv.go
@@ -110,7 +110,10 @@ func (cc *ClientConversation) finalMsg(s1 string) (string, error) {
 	authMsg := cc.c1b + "," + s1 + "," + c2wop
 
 	// Get derived keys from client cache
-	dk := cc.client.getDerivedKeys(KeyFactors{Salt: string(msg.salt), Iters: msg.iters})
+	dk, err := cc.client.getDerivedKeys(KeyFactors{Salt: string(msg.salt), Iters: msg.iters})
+	if err != nil {
+		return "", err
+	}
 
 	// Create proof as clientkey XOR clientsignature
 	clientSignature := computeHMAC(cc.hashGen, dk.StoredKey, []byte(authMsg))

--- a/pbkdf2_go124.go
+++ b/pbkdf2_go124.go
@@ -1,0 +1,18 @@
+// Copyright 2018 by David A. Golden. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build go1.24
+
+package scram
+
+import (
+	"crypto/pbkdf2"
+	"hash"
+)
+
+func pbkdf2Key(h func() hash.Hash, password string, salt []byte, iter, keyLength int) ([]byte, error) {
+	return pbkdf2.Key(h, password, salt, iter, keyLength)
+}

--- a/pbkdf2_legacy.go
+++ b/pbkdf2_legacy.go
@@ -1,0 +1,19 @@
+// Copyright 2018 by David A. Golden. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build !go1.24
+
+package scram
+
+import (
+	"hash"
+
+	"github.com/xdg-go/pbkdf2"
+)
+
+func pbkdf2Key(h func() hash.Hash, password string, salt []byte, iter, keyLength int) ([]byte, error) {
+	return pbkdf2.Key([]byte(password), salt, iter, keyLength, h), nil
+}

--- a/server_conv_test.go
+++ b/server_conv_test.go
@@ -55,7 +55,10 @@ func genServerCallback(c TestCase) (CredentialLookup, error) {
 		return nil, fmt.Errorf("error generating client for credential callback: %v", err)
 	}
 
-	stored := client.GetStoredCredentials(kf)
+	stored, err := client.GetStoredCredentials(kf)
+	if err != nil {
+		return nil, fmt.Errorf("error getting stored credentials: %w", err)
+	}
 
 	cbFcn := func(s string) (StoredCredentials, error) {
 		if s == userprep {


### PR DESCRIPTION
replace custom crypto lib with stdlib

allow to better handle errors and fully use fips mode (https://go.dev/doc/security/fips140)

