### PR TITLE
Implement channel binding support for SCRAM-PLUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **Channel binding support for SCRAM-PLUS variants** (RFC 5929, RFC 9266)
 - `GetStoredCredentialsWithError()` method that returns errors from PBKDF2
   key derivation instead of panicking.
 - Support for Go 1.24+ stdlib `crypto/pbkdf2` package, which provides

--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@
 
 Package scram provides client and server implementations of the Salted
 Challenge Response Authentication Mechanism (SCRAM) described in
-[RFC-5802](https://tools.ietf.org/html/rfc5802) and
-[RFC-7677](https://tools.ietf.org/html/rfc7677).
+- [RFC-5802](https://tools.ietf.org/html/rfc5802)
+- [RFC-5929](https://tools.ietf.org/html/rfc5929)
+- [RFC-7677](https://tools.ietf.org/html/rfc7677)
+- [RFC-9266](https://tools.ietf.org/html/rfc9266)
 
 It includes both client and server side support.
 
-Channel binding and extensions are not (yet) supported.
+Channel binding is supported for SCRAM-PLUS variants, including:
+- `tls-unique` (RFC 5929) - for TLS ≤ 1.2
+- `tls-server-end-point` (RFC 5929) - for all TLS versions
+- `tls-exporter` (RFC 9266) - recommended for TLS 1.3+
+
+SCRAM message extensions are not supported.
 
 ## Examples
 
@@ -62,6 +69,41 @@ Channel binding and extensions are not (yet) supported.
     func sendClientMsg(s string) string {
         // A real implementation would send this to a server and read a reply.
         return ""
+    }
+
+### Client side with channel binding (SCRAM-PLUS)
+
+    package main
+
+    import (
+        "crypto/tls"
+        "github.com/xdg-go/scram"
+    )
+
+    func main() {
+        // Establish TLS connection
+        tlsConn, err := tls.Dial("tcp", "server:port", &tls.Config{MinVersion: tls.VersionTLS13})
+        if err != nil {
+            panic(err)
+        }
+        defer tlsConn.Close()
+
+        // Get Client with username, password
+        client, err := scram.SHA256.NewClient("mulder", "trustno1", "")
+        if err != nil {
+            panic(err)
+        }
+
+        // Create channel binding from TLS connection (TLS 1.3 example)
+        // Use NewTLSExporterBinding for TLS 1.3+, NewTLSServerEndpointBinding for all TLS versions
+        channelBinding, err := scram.NewTLSExporterBinding(&tlsConn.ConnectionState())
+        if err != nil {
+            panic(err)
+        }
+
+        // Create conversation with channel binding for SCRAM-SHA-256-PLUS
+        conv := client.NewConversationWithChannelBinding(channelBinding)
+        // ... rest of authentication conversation
     }
 
 ## Copyright and License

--- a/channel_binding.go
+++ b/channel_binding.go
@@ -1,0 +1,142 @@
+// Copyright 2018 by David A. Golden. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package scram
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"hash"
+)
+
+// ChannelBindingType represents the type of channel binding to use with
+// SCRAM-PLUS authentication variants.  The type must match one of the
+// channel binding types defined in RFC 5056, RFC 5929, or RFC 9266.
+type ChannelBindingType string
+
+const (
+	// ChannelBindingNone indicates no channel binding is used.
+	ChannelBindingNone ChannelBindingType = ""
+
+	// ChannelBindingTLSUnique uses the TLS Finished message from the first
+	// TLS handshake (RFC 5929).  This is not safe for TLS 1.3 and should
+	// generally be avoided.
+	ChannelBindingTLSUnique ChannelBindingType = "tls-unique"
+
+	// ChannelBindingTLSServerEndpoint uses a hash of the server's certificate
+	// (RFC 5929).  This works with all TLS versions including TLS 1.3.
+	ChannelBindingTLSServerEndpoint ChannelBindingType = "tls-server-end-point"
+
+	// ChannelBindingTLSExporter uses TLS Exported Keying Material with the
+	// label "EXPORTER-Channel-Binding" (RFC 9266).  This is the recommended
+	// channel binding type for TLS 1.3.
+	ChannelBindingTLSExporter ChannelBindingType = "tls-exporter"
+)
+
+// ChannelBinding holds the channel binding type and data for SCRAM-PLUS
+// authentication. Use constructors to create type-specific bindings.
+type ChannelBinding struct {
+	Type ChannelBindingType
+	Data []byte
+}
+
+// IsSupported returns true if the channel binding is configured with a
+// non-empty type and data.
+func (cb ChannelBinding) IsSupported() bool {
+	return cb.Type != ChannelBindingNone && len(cb.Data) > 0
+}
+
+// Matches returns true if this channel binding matches another channel
+// binding in both type and data.
+func (cb ChannelBinding) Matches(other ChannelBinding) bool {
+	if cb.Type != other.Type {
+		return false
+	}
+	return hmac.Equal(cb.Data, other.Data)
+}
+
+// NewTLSUniqueBinding creates a ChannelBinding for tls-unique channel binding.
+// Since Go's standard library doesn't expose the TLS Finished message,
+// applications must provide the data directly.
+//
+// Note: tls-unique is not safe for TLS 1.3 and should generally be avoided.
+// Use tls-exporter instead for TLS 1.3+.
+func NewTLSUniqueBinding(data []byte) ChannelBinding {
+	return ChannelBinding{
+		Type: ChannelBindingTLSUnique,
+		Data: data,
+	}
+}
+
+// NewTLSServerEndpointBinding creates a ChannelBinding for tls-server-end-point
+// channel binding per RFC 5929. It extracts the server's certificate from
+// the TLS connection state and hashes it using the appropriate hash function
+// based on the certificate's signature algorithm.
+//
+// This works with all TLS versions including TLS 1.3.
+func NewTLSServerEndpointBinding(connState *tls.ConnectionState) (ChannelBinding, error) {
+	if connState == nil {
+		return ChannelBinding{}, errors.New("connection state is nil")
+	}
+
+	if len(connState.PeerCertificates) == 0 {
+		return ChannelBinding{}, errors.New("no peer certificates")
+	}
+
+	cert := connState.PeerCertificates[0]
+
+	// Determine hash algorithm per RFC 5929
+	var h hash.Hash
+	switch cert.SignatureAlgorithm {
+	case x509.MD5WithRSA, x509.SHA1WithRSA, x509.DSAWithSHA1,
+		x509.ECDSAWithSHA1:
+		h = sha256.New() // Use SHA-256 for MD5/SHA-1
+	case x509.SHA256WithRSA, x509.SHA256WithRSAPSS,
+		x509.ECDSAWithSHA256:
+		h = sha256.New()
+	case x509.SHA384WithRSA, x509.SHA384WithRSAPSS,
+		x509.ECDSAWithSHA384:
+		h = sha512.New384()
+	case x509.SHA512WithRSA, x509.SHA512WithRSAPSS,
+		x509.ECDSAWithSHA512:
+		h = sha512.New()
+	default:
+		return ChannelBinding{}, fmt.Errorf("unsupported signature algorithm: %v",
+			cert.SignatureAlgorithm)
+	}
+
+	h.Write(cert.Raw)
+	return ChannelBinding{
+		Type: ChannelBindingTLSServerEndpoint,
+		Data: h.Sum(nil),
+	}, nil
+}
+
+// NewTLSExporterBinding creates a ChannelBinding for tls-exporter channel binding
+// per RFC 9266. It uses TLS Exported Keying Material with the label
+// "EXPORTER-Channel-Binding" and an empty context.
+//
+// This is the recommended channel binding type for TLS 1.3+.
+func NewTLSExporterBinding(connState *tls.ConnectionState) (ChannelBinding, error) {
+	if connState == nil {
+		return ChannelBinding{}, errors.New("connection state is nil")
+	}
+
+	cbData, err := connState.ExportKeyingMaterial("EXPORTER-Channel-Binding", nil, 32)
+	if err != nil {
+		return ChannelBinding{}, fmt.Errorf("failed to export keying material: %w", err)
+	}
+
+	return ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: cbData,
+	}, nil
+}

--- a/channel_binding_test.go
+++ b/channel_binding_test.go
@@ -1,0 +1,858 @@
+// Copyright 2018 by David A. Golden. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package scram
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestChannelBindingTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cbType   ChannelBindingType
+		expected string
+	}{
+		{"None", ChannelBindingNone, ""},
+		{"TLS Unique", ChannelBindingTLSUnique, "tls-unique"},
+		{"TLS Server Endpoint", ChannelBindingTLSServerEndpoint, "tls-server-end-point"},
+		{"TLS Exporter", ChannelBindingTLSExporter, "tls-exporter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.cbType) != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, string(tt.cbType))
+			}
+		})
+	}
+}
+
+func TestChannelBindingIsSupported(t *testing.T) {
+	tests := []struct {
+		name     string
+		cb       ChannelBinding
+		expected bool
+	}{
+		{
+			name:     "Empty binding",
+			cb:       ChannelBinding{},
+			expected: false,
+		},
+		{
+			name:     "Type but no data",
+			cb:       ChannelBinding{Type: ChannelBindingTLSExporter, Data: nil},
+			expected: false,
+		},
+		{
+			name:     "Data but no type",
+			cb:       ChannelBinding{Type: ChannelBindingNone, Data: []byte("test")},
+			expected: false,
+		},
+		{
+			name:     "Type and data",
+			cb:       ChannelBinding{Type: ChannelBindingTLSExporter, Data: []byte("test")},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cb.IsSupported() != tt.expected {
+				t.Errorf("Expected IsSupported=%v, got %v", tt.expected, tt.cb.IsSupported())
+			}
+		})
+	}
+}
+
+func TestChannelBindingMatches(t *testing.T) {
+	cb1 := ChannelBinding{Type: ChannelBindingTLSExporter, Data: []byte("test-data")}
+	cb2 := ChannelBinding{Type: ChannelBindingTLSExporter, Data: []byte("test-data")}
+	cb3 := ChannelBinding{Type: ChannelBindingTLSExporter, Data: []byte("different")}
+	cb4 := ChannelBinding{Type: ChannelBindingTLSServerEndpoint, Data: []byte("test-data")}
+
+	tests := []struct {
+		name     string
+		cb1      ChannelBinding
+		cb2      ChannelBinding
+		expected bool
+	}{
+		{"Same type and data", cb1, cb2, true},
+		{"Same type, different data", cb1, cb3, false},
+		{"Different type, same data", cb1, cb4, false},
+		{"Different type and data", cb1, cb3, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cb1.Matches(tt.cb2) != tt.expected {
+				t.Errorf("Expected Matches=%v, got %v", tt.expected, tt.cb1.Matches(tt.cb2))
+			}
+		})
+	}
+}
+
+func TestClientChannelBinding(t *testing.T) {
+	client, _ := SHA256.NewClient("user", "pencil", "")
+
+	// Test without channel binding
+	conv1 := client.NewConversation()
+	msg1, _ := conv1.Step("")
+	if !strings.HasPrefix(msg1, "n,,") {
+		t.Errorf("Expected gs2-header to start with 'n,,', got %q", msg1[:10])
+	}
+
+	// Test with tls-exporter channel binding
+	cbData := []byte("test-channel-binding-data")
+	conv2 := client.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: cbData,
+	})
+
+	msg2, _ := conv2.Step("")
+	if !strings.HasPrefix(msg2, "p=tls-exporter,,") {
+		t.Errorf("Expected gs2-header to start with 'p=tls-exporter,,', got %q", msg2[:20])
+	}
+
+	// Verify conversation has channel binding
+	if !conv2.channelBinding.IsSupported() {
+		t.Error("Expected conversation to have channel binding")
+	}
+	if conv2.channelBinding.Type != ChannelBindingTLSExporter {
+		t.Errorf("Expected type %q, got %q", ChannelBindingTLSExporter, conv2.channelBinding.Type)
+	}
+}
+
+func TestClientServerChannelBindingIntegration(t *testing.T) {
+	username := "user"
+	password := "pencil"
+	cbData := []byte("test-channel-binding-data")
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run authentication conversation with channel binding
+	clientConv := client.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: cbData,
+	})
+	serverConv := server.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: cbData,
+	})
+
+	// Client first message
+	clientFirst, err := clientConv.Step("")
+	if err != nil {
+		t.Fatalf("Client first step failed: %v", err)
+	}
+
+	// Server first message
+	serverFirst, err := serverConv.Step(clientFirst)
+	if err != nil {
+		t.Fatalf("Server first step failed: %v", err)
+	}
+
+	// Client final message
+	clientFinal, err := clientConv.Step(serverFirst)
+	if err != nil {
+		t.Fatalf("Client final step failed: %v", err)
+	}
+
+	// Server final message
+	serverFinal, err := serverConv.Step(clientFinal)
+	if err != nil {
+		t.Fatalf("Server final step failed: %v", err)
+	}
+
+	// Client validation
+	_, err = clientConv.Step(serverFinal)
+	if err != nil {
+		t.Fatalf("Client validation failed: %v", err)
+	}
+
+	// Verify both sides are valid
+	if !clientConv.Valid() {
+		t.Error("Client conversation should be valid")
+	}
+	if !serverConv.Valid() {
+		t.Error("Server conversation should be valid")
+	}
+}
+
+func TestClientServerChannelBindingMismatch(t *testing.T) {
+	username := "user"
+	password := "pencil"
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run authentication conversation with mismatched channel binding
+	clientConv := client.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("client-data"),
+	})
+	serverConv := server.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("server-data"),
+	})
+
+	// Client first message
+	clientFirst, _ := clientConv.Step("")
+
+	// Server first message
+	serverFirst, _ := serverConv.Step(clientFirst)
+
+	// Client final message
+	clientFinal, _ := clientConv.Step(serverFirst)
+
+	// Server final message should fail due to channel binding mismatch
+	_, err := serverConv.Step(clientFinal)
+	if err == nil {
+		t.Fatal("Expected error due to channel binding mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "channel binding mismatch") {
+		t.Errorf("Expected 'channel binding mismatch' error, got: %v", err)
+	}
+
+	// Server should not be valid
+	if serverConv.Valid() {
+		t.Error("Server conversation should not be valid")
+	}
+}
+
+func TestServerRejectsChannelBindingWhenNotConfigured(t *testing.T) {
+	username := "user"
+	password := "pencil"
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run authentication conversation - client with channel binding, server without
+	clientConv := client.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("test-data"),
+	})
+	serverConv := server.NewConversation()
+	// No channel binding configured on server
+
+	// Client first message
+	clientFirst, _ := clientConv.Step("")
+
+	// Server should reject the client's channel binding request
+	_, err := serverConv.Step(clientFirst)
+	if err == nil {
+		t.Fatal("Expected error when server doesn't support channel binding, got nil")
+	}
+	if !strings.Contains(err.Error(), "channel binding") {
+		t.Errorf("Expected channel binding error, got: %v", err)
+	}
+}
+
+func TestServerRejectsUnsupportedChannelBindingType(t *testing.T) {
+	username := "user"
+	password := "pencil"
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run authentication conversation - client with tls-exporter, server with tls-server-end-point
+	clientConv := client.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("test-data"),
+	})
+	serverConv := server.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSServerEndpoint,
+		Data: []byte("test-data"),
+	})
+
+	// Client first message
+	clientFirst, _ := clientConv.Step("")
+
+	// Server should reject the unsupported channel binding type
+	_, err := serverConv.Step(clientFirst)
+	if err == nil {
+		t.Fatal("Expected error for unsupported channel binding type, got nil")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "tls-exporter") || !strings.Contains(errMsg, "tls-server-end-point") {
+		t.Errorf("Expected error about channel binding type mismatch, got: %v", err)
+	}
+}
+
+func TestClientWithoutChannelBindingWorksWithServerWithChannelBinding(t *testing.T) {
+	username := "user"
+	password := "pencil"
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run authentication conversation - client without channel binding, server with
+	clientConv := client.NewConversation()
+	serverConv := server.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("test-data"),
+	})
+
+	// Client first message
+	clientFirst, err := clientConv.Step("")
+	if err != nil {
+		t.Fatalf("Client first step failed: %v", err)
+	}
+
+	// Server first message (should accept client without channel binding)
+	serverFirst, err := serverConv.Step(clientFirst)
+	if err != nil {
+		t.Fatalf("Server first step failed: %v", err)
+	}
+
+	// Client final message
+	clientFinal, err := clientConv.Step(serverFirst)
+	if err != nil {
+		t.Fatalf("Client final step failed: %v", err)
+	}
+
+	// Server final message
+	serverFinal, err := serverConv.Step(clientFinal)
+	if err != nil {
+		t.Fatalf("Server final step failed: %v", err)
+	}
+
+	// Client validation
+	_, err = clientConv.Step(serverFinal)
+	if err != nil {
+		t.Fatalf("Client validation failed: %v", err)
+	}
+
+	// Verify both sides are valid
+	if !clientConv.Valid() {
+		t.Error("Client conversation should be valid")
+	}
+	if !serverConv.Valid() {
+		t.Error("Server conversation should be valid")
+	}
+}
+
+func TestAllChannelBindingTypes(t *testing.T) {
+	username := "user"
+	password := "pencil"
+
+	bindingTypes := []ChannelBindingType{
+		ChannelBindingTLSUnique,
+		ChannelBindingTLSServerEndpoint,
+		ChannelBindingTLSExporter,
+	}
+
+	for _, cbType := range bindingTypes {
+		t.Run(string(cbType), func(t *testing.T) {
+			cbData := []byte("test-data-for-" + string(cbType))
+
+			// Setup client
+			client, _ := SHA256.NewClient(username, password, "")
+
+			// Setup server
+			credLookup := func(username string) (StoredCredentials, error) {
+				client, _ := SHA256.NewClient(username, password, "")
+				salt := []byte("QSXCR+Q6sek8bf92")
+				return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+			}
+			server, _ := SHA256.NewServer(credLookup)
+
+			// Run full authentication with channel binding
+			clientConv := client.NewConversationWithChannelBinding(ChannelBinding{
+				Type: cbType,
+				Data: cbData,
+			})
+			serverConv := server.NewConversationWithChannelBinding(ChannelBinding{
+				Type: cbType,
+				Data: cbData,
+			})
+
+			clientFirst, _ := clientConv.Step("")
+			serverFirst, _ := serverConv.Step(clientFirst)
+			clientFinal, _ := clientConv.Step(serverFirst)
+			serverFinal, _ := serverConv.Step(clientFinal)
+			_, err := clientConv.Step(serverFinal)
+
+			if err != nil {
+				t.Fatalf("Authentication failed for %s: %v", cbType, err)
+			}
+
+			if !clientConv.Valid() || !serverConv.Valid() {
+				t.Errorf("Authentication not valid for %s", cbType)
+			}
+		})
+	}
+}
+
+func TestServerWithChannelBindingRequired_RejectsClientWithoutChannelBinding(t *testing.T) {
+	username := "user"
+	password := "pencil"
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run authentication conversation - client without channel binding, server requires it
+	clientConv := client.NewConversation()
+	serverConv := server.NewConversationWithChannelBindingRequired(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("test-data"),
+	})
+
+	// Client first message (will use "n" flag since no channel binding configured)
+	clientFirst, _ := clientConv.Step("")
+
+	// Server should reject due to channel binding being required
+	_, err := serverConv.Step(clientFirst)
+	if err == nil {
+		t.Fatal("Expected error when server requires channel binding but client doesn't support it, got nil")
+	}
+	if !strings.Contains(err.Error(), "channel binding") && !strings.Contains(err.Error(), "requires") {
+		t.Errorf("Expected 'channel binding required' error, got: %v", err)
+	}
+}
+
+func TestServerWithChannelBindingRequired_RejectsDowngradeAttack(t *testing.T) {
+	password := "pencil"
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	serverConv := server.NewConversationWithChannelBindingRequired(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("test-data"),
+	})
+
+	// Craft a client-first message with "y" flag (client supports channel binding
+	// but thinks server doesn't advertise PLUS variant)
+	// Format: gs2-header "," [ authzid ] "," username "," nonce
+	// gs2-header: "y" "," [ authzid ]
+	clientFirst := "y,,n=user,r=clientnonce123"
+
+	// Server should reject this as a downgrade attack
+	_, err := serverConv.Step(clientFirst)
+	if err == nil {
+		t.Fatal("Expected error for downgrade attack (y flag when server advertised PLUS), got nil")
+	}
+	if !strings.Contains(err.Error(), "downgrade") || !strings.Contains(err.Error(), "y") {
+		t.Errorf("Expected 'downgrade attack' error, got: %v", err)
+	}
+}
+
+func TestServerWithChannelBindingRequired_AcceptsClientWithChannelBinding(t *testing.T) {
+	username := "user"
+	password := "pencil"
+	cbData := []byte("test-data")
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run full authentication with channel binding required - should succeed
+	clientConv := client.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: cbData,
+	})
+	serverConv := server.NewConversationWithChannelBindingRequired(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: cbData,
+	})
+
+	clientFirst, _ := clientConv.Step("")
+	serverFirst, _ := serverConv.Step(clientFirst)
+	clientFinal, _ := clientConv.Step(serverFirst)
+	serverFinal, err := serverConv.Step(clientFinal)
+	if err != nil {
+		t.Fatalf("Server step failed: %v", err)
+	}
+
+	_, err = clientConv.Step(serverFinal)
+	if err != nil {
+		t.Fatalf("Client validation failed: %v", err)
+	}
+
+	if !clientConv.Valid() || !serverConv.Valid() {
+		t.Error("Authentication should be valid when both client and server use matching channel binding")
+	}
+}
+
+func TestServerWithOptionalChannelBinding_AcceptsClientWithoutChannelBinding(t *testing.T) {
+	username := "user"
+	password := "pencil"
+
+	// Setup client
+	client, _ := SHA256.NewClient(username, password, "")
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	// Run full authentication - server with optional channel binding, client without
+	clientConv := client.NewConversation()
+	serverConv := server.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("test-data"),
+	})
+
+	clientFirst, _ := clientConv.Step("")
+	serverFirst, _ := serverConv.Step(clientFirst)
+	clientFinal, _ := clientConv.Step(serverFirst)
+	serverFinal, err := serverConv.Step(clientFinal)
+	if err != nil {
+		t.Fatalf("Server step failed: %v", err)
+	}
+
+	_, err = clientConv.Step(serverFinal)
+	if err != nil {
+		t.Fatalf("Client validation failed: %v", err)
+	}
+
+	if !clientConv.Valid() || !serverConv.Valid() {
+		t.Error("Authentication should be valid - server has optional channel binding")
+	}
+}
+
+func TestServerWithOptionalChannelBinding_RejectsDowngradeAttack(t *testing.T) {
+	password := "pencil"
+
+	// Setup server
+	credLookup := func(username string) (StoredCredentials, error) {
+		client, _ := SHA256.NewClient(username, password, "")
+		salt := []byte("QSXCR+Q6sek8bf92")
+		return client.GetStoredCredentials(KeyFactors{Salt: string(salt), Iters: 4096}), nil
+	}
+	server, _ := SHA256.NewServer(credLookup)
+
+	serverConv := server.NewConversationWithChannelBinding(ChannelBinding{
+		Type: ChannelBindingTLSExporter,
+		Data: []byte("test-data"),
+	})
+
+	// Craft a client-first message with "y" flag (client supports channel binding
+	// but thinks server doesn't advertise PLUS variant)
+	// This is a downgrade attack even when channel binding is optional
+	clientFirst := "y,,n=user,r=clientnonce123"
+
+	// Server should reject this as a downgrade attack
+	_, err := serverConv.Step(clientFirst)
+	if err == nil {
+		t.Fatal("Expected error for downgrade attack (y flag when server advertised PLUS), got nil")
+	}
+	if !strings.Contains(err.Error(), "downgrade") || !strings.Contains(err.Error(), "y") {
+		t.Errorf("Expected 'downgrade attack' error, got: %v", err)
+	}
+}
+
+// Helper function to create a test certificate
+func createTestCert(t *testing.T, sigAlg x509.SignatureAlgorithm) *x509.Certificate {
+	t.Helper()
+
+	// Use ECDSA for all signature algorithms for simplicity in testing
+	// What matters for channel binding is the certificate's Raw bytes and
+	// the SignatureAlgorithm field, not the actual key type match
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate private key: %v", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("Failed to generate serial number: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		// Use ECDSA signature for actual signing
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("Failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
+
+	// Override the signature algorithm in the parsed cert to test different hash behaviors
+	cert.SignatureAlgorithm = sigAlg
+
+	return cert
+}
+
+// Helper function to create a mock TLS connection state with a certificate
+func createMockConnState(t *testing.T, cert *x509.Certificate) *tls.ConnectionState {
+	t.Helper()
+
+	return &tls.ConnectionState{
+		Version:           tls.VersionTLS13,
+		HandshakeComplete: true,
+		PeerCertificates:  []*x509.Certificate{cert},
+	}
+}
+
+func TestNewTLSUniqueBinding(t *testing.T) {
+	testData := []byte("test-tls-unique-data")
+
+	cb := NewTLSUniqueBinding(testData)
+
+	if cb.Type != ChannelBindingTLSUnique {
+		t.Errorf("Expected type %q, got %q", ChannelBindingTLSUnique, cb.Type)
+	}
+
+	if string(cb.Data) != string(testData) {
+		t.Errorf("Expected data %q, got %q", testData, cb.Data)
+	}
+
+	if !cb.IsSupported() {
+		t.Error("Expected channel binding to be supported")
+	}
+}
+
+func TestNewTLSServerEndpointBinding(t *testing.T) {
+	tests := []struct {
+		name   string
+		sigAlg x509.SignatureAlgorithm
+	}{
+		{"SHA256WithRSA", x509.SHA256WithRSA},
+		{"SHA256WithRSAPSS", x509.SHA256WithRSAPSS},
+		{"ECDSAWithSHA256", x509.ECDSAWithSHA256},
+		{"ECDSAWithSHA384", x509.ECDSAWithSHA384},
+		{"ECDSAWithSHA512", x509.ECDSAWithSHA512},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert := createTestCert(t, tt.sigAlg)
+			connState := createMockConnState(t, cert)
+
+			cb, err := NewTLSServerEndpointBinding(connState)
+			if err != nil {
+				t.Fatalf("NewTLSServerEndpointBinding failed: %v", err)
+			}
+
+			if cb.Type != ChannelBindingTLSServerEndpoint {
+				t.Errorf("Expected type %q, got %q", ChannelBindingTLSServerEndpoint, cb.Type)
+			}
+
+			if len(cb.Data) == 0 {
+				t.Error("Expected non-empty channel binding data")
+			}
+
+			if !cb.IsSupported() {
+				t.Error("Expected channel binding to be supported")
+			}
+		})
+	}
+}
+
+func TestNewTLSServerEndpointBinding_NilConnectionState(t *testing.T) {
+	_, err := NewTLSServerEndpointBinding(nil)
+	if err == nil {
+		t.Fatal("Expected error for nil connection state, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Errorf("Expected 'nil' in error message, got: %v", err)
+	}
+}
+
+func TestNewTLSServerEndpointBinding_NoPeerCertificates(t *testing.T) {
+	connState := &tls.ConnectionState{
+		Version:           tls.VersionTLS13,
+		HandshakeComplete: true,
+		PeerCertificates:  []*x509.Certificate{},
+	}
+
+	_, err := NewTLSServerEndpointBinding(connState)
+	if err == nil {
+		t.Fatal("Expected error for no peer certificates, got nil")
+	}
+	if !strings.Contains(err.Error(), "no peer certificates") {
+		t.Errorf("Expected 'no peer certificates' in error message, got: %v", err)
+	}
+}
+
+func TestNewTLSServerEndpointBinding_ConsistentHashing(t *testing.T) {
+	// Create a certificate and verify that hashing is deterministic
+	cert := createTestCert(t, x509.ECDSAWithSHA256)
+	connState := createMockConnState(t, cert)
+
+	cb1, err1 := NewTLSServerEndpointBinding(connState)
+	if err1 != nil {
+		t.Fatalf("First call failed: %v", err1)
+	}
+
+	cb2, err2 := NewTLSServerEndpointBinding(connState)
+	if err2 != nil {
+		t.Fatalf("Second call failed: %v", err2)
+	}
+
+	if !cb1.Matches(cb2) {
+		t.Error("Expected consistent hashing for the same certificate")
+	}
+}
+
+func TestNewTLSServerEndpointBinding_SHA1UpgradedToSHA256(t *testing.T) {
+	// SHA-1 and MD5 signatures should be upgraded to SHA-256
+	cert := createTestCert(t, x509.SHA1WithRSA)
+	connState := createMockConnState(t, cert)
+
+	cb, err := NewTLSServerEndpointBinding(connState)
+	if err != nil {
+		t.Fatalf("NewTLSServerEndpointBinding failed: %v", err)
+	}
+
+	// The hash should be SHA-256 (32 bytes)
+	if len(cb.Data) != sha256.Size {
+		t.Errorf("Expected SHA-256 hash length of %d bytes, got %d bytes", sha256.Size, len(cb.Data))
+	}
+}
+
+func TestNewTLSExporterBinding(t *testing.T) {
+	// Note: We can't fully test ExportKeyingMaterial without a real TLS connection,
+	// but we can test that the constructor handles the connection state properly.
+
+	t.Run("NilConnectionState", func(t *testing.T) {
+		_, err := NewTLSExporterBinding(nil)
+		if err == nil {
+			t.Fatal("Expected error for nil connection state, got nil")
+		}
+		if !strings.Contains(err.Error(), "nil") {
+			t.Errorf("Expected 'nil' in error message, got: %v", err)
+		}
+	})
+}
+
+func TestChannelBindingConstructors_Integration(t *testing.T) {
+	// Test that constructors create ChannelBinding structs that work
+	// with the existing authentication flow
+
+	username := "user"
+	password := "pencil"
+
+	t.Run("TLSUnique", func(t *testing.T) {
+		cbData := []byte("test-tls-unique-data")
+		cb := NewTLSUniqueBinding(cbData)
+
+		client, _ := SHA256.NewClient(username, password, "")
+
+		conv := client.NewConversationWithChannelBinding(cb)
+		msg, err := conv.Step("")
+		if err != nil {
+			t.Fatalf("Client step failed: %v", err)
+		}
+
+		if !strings.HasPrefix(msg, "p=tls-unique,,") {
+			t.Errorf("Expected message to start with 'p=tls-unique,,', got %q", msg[:20])
+		}
+	})
+
+	t.Run("TLSServerEndpoint", func(t *testing.T) {
+		cert := createTestCert(t, x509.ECDSAWithSHA256)
+		connState := createMockConnState(t, cert)
+
+		cb, err := NewTLSServerEndpointBinding(connState)
+		if err != nil {
+			t.Fatalf("NewTLSServerEndpointBinding failed: %v", err)
+		}
+
+		client, _ := SHA256.NewClient(username, password, "")
+
+		conv := client.NewConversationWithChannelBinding(cb)
+		msg, err := conv.Step("")
+		if err != nil {
+			t.Fatalf("Client step failed: %v", err)
+		}
+
+		if !strings.HasPrefix(msg, "p=tls-server-end-point,,") {
+			t.Errorf("Expected message to start with 'p=tls-server-end-point,,', got %q", msg[:30])
+		}
+	})
+}

--- a/client.go
+++ b/client.go
@@ -79,6 +79,23 @@ func (c *Client) NewConversation() *ClientConversation {
 	}
 }
 
+// NewConversationWithChannelBinding constructs a client-side authentication
+// conversation with channel binding for SCRAM-PLUS authentication. Channel
+// binding is connection-specific, so a new conversation should be created for
+// each connection being authenticated. Conversations cannot be reused, so this
+// must be called for each new authentication attempt.
+func (c *Client) NewConversationWithChannelBinding(cb ChannelBinding) *ClientConversation {
+	c.RLock()
+	defer c.RUnlock()
+	return &ClientConversation{
+		client:         c,
+		nonceGen:       c.nonceGen,
+		hashGen:        c.hashGen,
+		minIters:       c.minIters,
+		channelBinding: cb,
+	}
+}
+
 func (c *Client) getDerivedKeys(kf KeyFactors) (derivedKeys, error) {
 	dk, ok := c.getCache(kf)
 	if !ok {

--- a/common.go
+++ b/common.go
@@ -58,6 +58,45 @@ type StoredCredentials struct {
 // StoredCredentials.
 type CredentialLookup func(string) (StoredCredentials, error)
 
+// Server error values as defined in RFC-5802 and RFC-7677.
+// These are returned by the server in error responses as "e=<value>".
+const (
+	// ErrInvalidEncoding indicates the client message had invalid encoding
+	ErrInvalidEncoding = "e=invalid-encoding"
+
+	// ErrExtensionsNotSupported indicates unrecognized 'm' value
+	ErrExtensionsNotSupported = "e=extensions-not-supported"
+
+	// ErrInvalidProof indicates the authentication proof from the client was invalid
+	ErrInvalidProof = "e=invalid-proof"
+
+	// ErrChannelBindingsDontMatch indicates channel binding data didn't match expected value
+	ErrChannelBindingsDontMatch = "e=channel-bindings-dont-match"
+
+	// ErrServerDoesSupportChannelBinding indicates server does support channel
+	// binding. This is returned if a downgrade attack is detected.
+	ErrServerDoesSupportChannelBinding = "e=server-does-support-channel-binding"
+
+	// ErrChannelBindingNotSupported indicates channel binding is not supported
+	ErrChannelBindingNotSupported = "e=channel-binding-not-supported"
+
+	// ErrUnsupportedChannelBindingType indicates the requested channel binding type is not supported
+	ErrUnsupportedChannelBindingType = "e=unsupported-channel-binding-type"
+
+	// ErrUnknownUser indicates the specified user does not exist
+	ErrUnknownUser = "e=unknown-user"
+
+	// ErrInvalidUsernameEncoding indicates invalid username encoding (invalid UTF-8 or SASLprep failed)
+	ErrInvalidUsernameEncoding = "e=invalid-username-encoding"
+
+	// ErrNoResources indicates the server is out of resources
+	ErrNoResources = "e=no-resources"
+
+	// ErrOtherError is a catch-all for unspecified errors. The server may substitute
+	// the real reason with this error to prevent information disclosure.
+	ErrOtherError = "e=other-error"
+)
+
 func defaultNonceGenerator() string {
 	raw := make([]byte, 24)
 	nonce := make([]byte, base64.StdEncoding.EncodedLen(len(raw)))

--- a/common.go
+++ b/common.go
@@ -58,8 +58,8 @@ type StoredCredentials struct {
 // StoredCredentials.
 type CredentialLookup func(string) (StoredCredentials, error)
 
-// Server error values as defined in RFC-5802 and RFC-7677.
-// These are returned by the server in error responses as "e=<value>".
+// Server error values as defined in RFC-5802 and RFC-7677. These are returned
+// by the server in error responses as "e=<value>".
 const (
 	// ErrInvalidEncoding indicates the client message had invalid encoding
 	ErrInvalidEncoding = "e=invalid-encoding"
@@ -74,7 +74,8 @@ const (
 	ErrChannelBindingsDontMatch = "e=channel-bindings-dont-match"
 
 	// ErrServerDoesSupportChannelBinding indicates server does support channel
-	// binding. This is returned if a downgrade attack is detected.
+	// binding. This is returned if a downgrade attack is detected or if the
+	// client does not support binding and channel binding is required.
 	ErrServerDoesSupportChannelBinding = "e=server-does-support-channel-binding"
 
 	// ErrChannelBindingNotSupported indicates channel binding is not supported

--- a/doc.go
+++ b/doc.go
@@ -5,22 +5,49 @@
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 // Package scram provides client and server implementations of the Salted
-// Challenge Response Authentication Mechanism (SCRAM) described in RFC-5802
-// and RFC-7677.
+// Challenge Response Authentication Mechanism (SCRAM) described in RFC-5802,
+// RFC-7677, and RFC-9266.
 //
-// Usage
+// # Usage
 //
 // The scram package provides variables, `SHA1`, `SHA256`, and `SHA512`, that
 // are used to construct Client or Server objects.
 //
-//     clientSHA1,   err := scram.SHA1.NewClient(username, password, authID)
-//     clientSHA256, err := scram.SHA256.NewClient(username, password, authID)
-//     clientSHA512, err := scram.SHA512.NewClient(username, password, authID)
+//	clientSHA1,   err := scram.SHA1.NewClient(username, password, authID)
+//	clientSHA256, err := scram.SHA256.NewClient(username, password, authID)
+//	clientSHA512, err := scram.SHA512.NewClient(username, password, authID)
 //
-//     serverSHA1,   err := scram.SHA1.NewServer(credentialLookupFcn)
-//     serverSHA256, err := scram.SHA256.NewServer(credentialLookupFcn)
-//     serverSHA512, err := scram.SHA512.NewServer(credentialLookupFcn)
+//	serverSHA1,   err := scram.SHA1.NewServer(credentialLookupFcn)
+//	serverSHA256, err := scram.SHA256.NewServer(credentialLookupFcn)
+//	serverSHA512, err := scram.SHA512.NewServer(credentialLookupFcn)
 //
 // These objects are used to construct ClientConversation or
 // ServerConversation objects that are used to carry out authentication.
+//
+// Channel Binding (SCRAM-PLUS)
+//
+// The scram package supports channel binding for SCRAM-PLUS authentication
+// variants as described in RFC-5802, RFC-5929, and RFC-9266. Channel binding
+// cryptographically binds the SCRAM authentication to an underlying TLS
+// connection, preventing man-in-the-middle attacks.
+//
+// To use channel binding, create conversations with channel binding data
+// obtained from the TLS connection:
+//
+//	// Client example with tls-exporter (TLS 1.3+)
+//	client, _ := scram.SHA256.NewClient(username, password, "")
+//	channelBinding, _ := scram.NewTLSExporterBinding(&tlsConn.ConnectionState())
+//	clientConv := client.NewConversationWithChannelBinding(channelBinding)
+//
+//	// Server conversation with the same channel binding
+//	server, _ := scram.SHA256.NewServer(credentialLookupFcn)
+//	serverConv := server.NewConversationWithChannelBinding(channelBinding)
+//
+// Helper functions are provided to create ChannelBinding values from TLS connections:
+//   - NewTLSUniqueBinding: Uses TLS Finished message (RFC 5929, TLS ≤ 1.2)
+//   - NewTLSServerEndpointBinding: Uses server certificate hash (RFC 5929, all TLS versions)
+//   - NewTLSExporterBinding: Uses exported keying material (RFC 9266, recommended for TLS 1.3+)
+//
+// Channel binding is configured on conversations rather than clients or servers
+// because binding data is connection-specific.
 package scram

--- a/server_conv.go
+++ b/server_conv.go
@@ -95,7 +95,7 @@ func (sc *ServerConversation) firstMsg(c1 string) (string, error) {
 	sc.credential, err = sc.credentialCB(msg.username)
 	if err != nil {
 		sc.state = serverDone
-		return "e=unknown-user", err
+		return ErrUnknownUser, err
 	}
 
 	sc.nonce = msg.nonce + sc.nonceGen()
@@ -122,12 +122,12 @@ func (sc *ServerConversation) finalMsg(c2 string) (string, error) {
 	// with a data payload.  If we add binding, we need to independently
 	// compute the header to match here.
 	if string(msg.cbind) != sc.gs2Header {
-		return "e=channel-bindings-dont-match", fmt.Errorf("channel binding received '%s' doesn't match expected '%s'", msg.cbind, sc.gs2Header)
+		return ErrChannelBindingsDontMatch, fmt.Errorf("channel binding received '%s' doesn't match expected '%s'", msg.cbind, sc.gs2Header)
 	}
 
 	// Check nonce received matches what we sent
 	if msg.nonce != sc.nonce {
-		return "e=other-error", errors.New("nonce received did not match nonce sent")
+		return ErrOtherError, errors.New("nonce received did not match nonce sent")
 	}
 
 	// Create auth message
@@ -140,7 +140,7 @@ func (sc *ServerConversation) finalMsg(c2 string) (string, error) {
 
 	// Compare with constant-time function
 	if !hmac.Equal(storedKey, sc.credential.StoredKey) {
-		return "e=invalid-proof", errors.New("challenge proof invalid")
+		return ErrInvalidProof, errors.New("challenge proof invalid")
 	}
 
 	sc.valid = true

--- a/server_conv.go
+++ b/server_conv.go
@@ -25,18 +25,22 @@ const (
 // conversation with a client.  A new conversation must be created for
 // each authentication attempt.
 type ServerConversation struct {
-	nonceGen     NonceGeneratorFcn
-	hashGen      HashGeneratorFcn
-	credentialCB CredentialLookup
-	state        serverState
-	credential   StoredCredentials
-	valid        bool
-	gs2Header    string
-	username     string
-	authzID      string
-	nonce        string
-	c1b          string
-	s1           string
+	nonceGen              NonceGeneratorFcn
+	hashGen               HashGeneratorFcn
+	credentialCB          CredentialLookup
+	state                 serverState
+	credential            StoredCredentials
+	valid                 bool
+	gs2Header             string
+	username              string
+	authzID               string
+	nonce                 string
+	c1b                   string
+	s1                    string
+	channelBinding        ChannelBinding
+	requireChannelBinding bool
+	clientCBType          string
+	clientCBFlag          string
 }
 
 // Step takes a string provided from a client and attempts to move the
@@ -81,6 +85,69 @@ func (sc *ServerConversation) AuthzID() string {
 	return sc.authzID
 }
 
+// validateChannelBindingFlag validates the client's channel binding flag against
+// server configuration. The validation logic follows RFC 5802 section 6:
+//
+// Server configuration semantics:
+//   - WithChannelBindingRequired(cb): Server advertised PLUS variants AND requires them
+//   - WithChannelBinding(cb): Server advertised PLUS variants but doesn't require them
+//   - Neither called: Server did NOT advertise PLUS variants
+//
+// Client flag validation:
+//   - "n": Client doesn't support channel binding
+//   - "y": Client supports channel binding but server didn't advertise PLUS
+//   - "p": Client requires channel binding with specific type
+//
+// Returns server error string (empty if validation passes) and error.
+func (sc *ServerConversation) validateChannelBindingFlag() (string, error) {
+	advertised := sc.channelBinding.IsSupported()
+
+	switch sc.clientCBFlag {
+	case "n":
+		// Client doesn't support channel binding
+		if sc.requireChannelBinding {
+			// Policy violation: server requires channel binding
+			// Use ErrServerDoesSupportChannelBinding (defined for downgrade attacks)
+			// as the best available match to signal that server requires channel binding
+			return ErrServerDoesSupportChannelBinding,
+				errors.New("server requires channel binding but client doesn't support it")
+		}
+		// OK: server either doesn't advertise PLUS or advertises it optionally
+		return "", nil
+
+	case "y":
+		// Client supports channel binding but thinks server doesn't advertise PLUS
+		if advertised {
+			// Downgrade attack: we advertised PLUS but client didn't see it
+			return ErrServerDoesSupportChannelBinding,
+				errors.New("downgrade attack detected: client used 'y' but server advertised PLUS")
+		}
+		// OK: we didn't advertise PLUS, client correctly detected this
+		return "", nil
+
+	case "p":
+		// Client requires channel binding with specific type
+		if !advertised {
+			// Server doesn't support channel binding
+			return ErrChannelBindingNotSupported,
+				errors.New("client requires channel binding but server doesn't support it")
+		}
+		if ChannelBindingType(sc.clientCBType) != sc.channelBinding.Type {
+			// Server supports channel binding but not the requested type
+			return ErrUnsupportedChannelBindingType,
+				fmt.Errorf("client requested %s but server only supports %s",
+					sc.clientCBType, sc.channelBinding.Type)
+		}
+		// OK: channel binding type matches
+		return "", nil
+
+	default:
+		// Invalid flag (should have been caught by parser)
+		return ErrOtherError,
+			fmt.Errorf("invalid channel binding flag: %s", sc.clientCBFlag)
+	}
+}
+
 func (sc *ServerConversation) firstMsg(c1 string) (string, error) {
 	msg, err := parseClientFirst(c1)
 	if err != nil {
@@ -89,8 +156,16 @@ func (sc *ServerConversation) firstMsg(c1 string) (string, error) {
 	}
 
 	sc.gs2Header = msg.gs2Header
+	sc.clientCBFlag = msg.gs2BindFlag
+	sc.clientCBType = msg.channelBinding
 	sc.username = msg.username
 	sc.authzID = msg.authzID
+
+	// Validate channel binding flag against server configuration
+	if serverErr, err := sc.validateChannelBindingFlag(); err != nil {
+		sc.state = serverDone
+		return serverErr, err
+	}
 
 	sc.credential, err = sc.credentialCB(msg.username)
 	if err != nil {
@@ -117,12 +192,20 @@ func (sc *ServerConversation) finalMsg(c2 string) (string, error) {
 		return "", err
 	}
 
-	// Check channel binding matches what we expect; in this case, we expect
-	// just the gs2 header we received as we don't support channel binding
-	// with a data payload.  If we add binding, we need to independently
-	// compute the header to match here.
-	if string(msg.cbind) != sc.gs2Header {
-		return ErrChannelBindingsDontMatch, fmt.Errorf("channel binding received '%s' doesn't match expected '%s'", msg.cbind, sc.gs2Header)
+	// Check channel binding data matches what we expect
+	var expectedCBind []byte
+	if sc.clientCBFlag == "p" {
+		// Client used channel binding - expect gs2 header + channel binding data
+		expectedCBind = append([]byte(sc.gs2Header), sc.channelBinding.Data...)
+	} else {
+		// Client didn't use channel binding - just expect gs2 header
+		expectedCBind = []byte(sc.gs2Header)
+	}
+
+	if !hmac.Equal(msg.cbind, expectedCBind) {
+		return ErrChannelBindingsDontMatch,
+			fmt.Errorf("channel binding mismatch: expected %x, got %x",
+				expectedCBind, msg.cbind)
 	}
 
 	// Check nonce received matches what we sent


### PR DESCRIPTION
This commit adds comprehensive channel binding support to enable SCRAM-PLUS authentication variants.

Core Changes:
- Added ChannelBindingType enumeration (tls-unique, tls-server-end-point, tls-exporter)
- Added ChannelBinding struct to hold binding type and data
- Implemented WithChannelBinding() methods for Client and Server
- Updated parsers to handle gs2-cbind-flag "p=<cb-type>" format
- Client conversations now include channel binding data in authentication
- Server conversations validate channel binding during authentication

RFCs Implemented:
- RFC 5802: SCRAM protocol with channel binding
- RFC 5929: Channel Bindings for TLS (tls-unique, tls-server-end-point)
- RFC 9266: Channel Bindings for TLS 1.3 (tls-exporter)